### PR TITLE
Log to stderr instead of raising an error, when the daemon receives an unexpected command

### DIFF
--- a/spotlightd.rb
+++ b/spotlightd.rb
@@ -132,7 +132,7 @@ class Spotlight
       close_gui
       delete_fifo_file
     else
-      raise "Unexpected command: #{command.inspect}"
+      $stderr.puts "Unexpected command: #{command.inspect}"
     end
   end
 


### PR DESCRIPTION
It's a better choice, rather than showing an error on the desktop.