### PR TITLE
Use a cache for additive searches

### DIFF
--- a/lib/pm_spotlight_daemon/services/search_service.rb
+++ b/lib/pm_spotlight_daemon/services/search_service.rb
@@ -5,6 +5,17 @@ require_relative '../../pm_spotlight_shared/shared_configuration'
 
 module PmSpotlightDaemon
   module Services
+
+    # Manages the search.
+    #
+    # The previous search result is cached, when a pattern is an extension of the previous, the
+    # result can be extracted from the cache, rather than performing a new search.
+    #
+    # There are two conditions:
+    #
+    # 1. on the previous search, the result must not have been cut
+    # 2. the SearchService filtering must match the Search module used
+    #
     class SearchService
       include PmSpotlightShared::SharedConfiguration
 
@@ -13,14 +24,27 @@ module PmSpotlightDaemon
         @search_result_publisher = PmSpotlightDaemon::Messaging::Publisher.new(self, 'search result', search_result_writer)
 
         @search = PmSpotlightDaemon::Modules::FindSearch.new(search_paths, skip_paths: skip_paths, include_directories: include_directories)
+
+        @last_search_pattern = nil
+        @last_search_result = nil
       end
 
       def listen
         while true
           pattern = @search_pattern_consumer.consume_last_message
 
-          search_result = search_files(pattern)
-          search_result = limit_result(search_result, LIMIT_SEARCH_RESULT_MESSAGE_SIZE)
+          if pattern.strip.empty?
+            search_result = []
+            limit_reached = true # prevent this result from being cached
+          elsif can_use_previous_result?(pattern)
+            search_result = extract_new_result_as_subset_of_previous(pattern)
+            limit_reached = false
+          else
+            search_result = search_files(pattern)
+            search_result, limit_reached = limit_result(search_result, LIMIT_SEARCH_RESULT_MESSAGE_SIZE)
+          end
+
+          update_cached_data(pattern, search_result, limit_reached)
 
           # This message contains both the pattern and the result; the pattern may be used by the
           # sorter.
@@ -32,19 +56,41 @@ module PmSpotlightDaemon
 
       private
 
-      def search_files(pattern)
-        return [] if pattern.strip.empty?
+      def can_use_previous_result?(pattern)
+        !pattern.empty? && @last_search_pattern && pattern.start_with?(@last_search_pattern)
+      end
 
+      def extract_new_result_as_subset_of_previous(pattern)
+        @last_search_result.select do |filename|
+          File.basename(filename).downcase.include?(pattern.downcase)
+        end
+      end
+
+      def update_cached_data(pattern, search_result, limit_reached)
+        # If the limit has been reached, a more specific pattern may include failes which were
+        # after the cutoff.
+        if limit_reached
+          @last_search_pattern = nil
+          @last_search_result = nil
+        else
+          @last_search_pattern = pattern
+          @last_search_result = search_result
+        end
+      end
+
+      def search_files(pattern)
         @search.search_files(pattern)
       end
 
       def limit_result(full_result, limit)
         # Naive and wasteful algorithm, but this is not a bottleneck.
-        full_result.each_with_object([]) do |filename, limited_result|
-          break limited_result if limited_result.join("\n").bytesize + filename.bytesize > limit
+        result = full_result.each_with_object([]) do |filename, limited_result|
+          return [limited_result, true] if limited_result.join("\n").bytesize + filename.bytesize > limit
 
           limited_result << filename
         end
+
+        [result, false]
       end
     end
   end


### PR DESCRIPTION
By caching the previous search result, when a pattern is an extension of the previous, the result can be extracted from the cache, rather than performing a new search.

There are two conditions:

1. on the previous search, the result must not have been cut
2. the SearchService filtering must match the Search module used

Closes #24.