### PR TITLE
Add `tk` (0.3.0) dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@
 
 source "https://rubygems.org"
 
+gem 'tk', '~> 0.3.0'
 gem 'simple_scripting', '~> 0.9.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,4 +12,4 @@ DEPENDENCIES
   simple_scripting (~> 0.9.3)
 
 BUNDLED WITH
-   1.15.1
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,12 +4,14 @@ GEM
     parseconfig (1.0.8)
     simple_scripting (0.9.3)
       parseconfig (~> 1.0)
+    tk (0.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   simple_scripting (~> 0.9.3)
+  tk (~> 0.3.0)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
The previous version, which was not specified in the Gemfile, was 0.2.0, which causes continuous warnings on Ruby 3.0.

The v0.4.0 causes an error on start, so v0.3.0 has been chosen.